### PR TITLE
Add how section and expand final call to action on home page

### DIFF
--- a/assets/js/backbone/apps/home/templates/home_view_template.html
+++ b/assets/js/backbone/apps/home/templates/home_view_template.html
@@ -38,4 +38,24 @@
         </div>
       </div>
   </div>
-  <div class="text-center final-call"><a class="login" href="/auth"><button class="btn btn-midas" id="center" data-i18n="home.callToAction">Get Started Today</button></a></div>
+  <div class="container-fluid padding-left-none padding-right-none how">
+    <h2>How does it work?</h2>
+    <div class="col-md-8">
+      <img class="img-responsive" src="/images/home/how-to@2x.png">
+    </div>
+    <div class="col-md-4">
+      <ol class="list-unstyled">
+        <li class="title">Browse opportunities on the site to find the one that is right for you.</li>
+        <li class="title">Then just click "I'm in" to get started.</li>
+        <li class="title">Post a discussion topic if you have questions.</li>
+      </ol>
+    </div>
+  </div>
+  <div class="container-fluid padding-left-none padding-right-none final-call">
+    <div class="text-center col-md-8 col-md-offset-2">
+      <p class="title">Find Open Opportunities that match your skills or let you explore new horizons while make an impact across government.</p>
+      <a class="login" href="/auth">
+        <button class="btn btn-midas" id="center">Discover More</button>
+      </a>
+    </div>
+  </div>

--- a/assets/styles/application.css
+++ b/assets/styles/application.css
@@ -1624,14 +1624,17 @@ ul.task-tags > li {
 }
 
 .home .final-call {
-  height: 200px;
   padding: 60px;
+  background-color: #e5e5e5;
+}
+.home .final-call .title {
+  font-size: 28px;
 }
 
 .home h2 {
   color: white;
-  margin: 20px 60px;
-  font-weight: 400;
+  margin: 60px 60px 40px;
+  font-weight: 900;
   font-size: 22px;
 }
 
@@ -1643,7 +1646,7 @@ ul.task-tags > li {
   margin: 0 auto;
 }
 
-.value-prop .title {
+.home .title {
   font-size: 22px;
   font-weight: 400;
   padding: 16px 0px;
@@ -1660,6 +1663,20 @@ ul.task-tags > li {
   display: block;
   margin-bottom: 10px;
 }
+
+.how > div {
+  padding: 0px 50px 60px 50px;
+}
+.how h2 {
+  color: #333;
+}
+.how li {
+  font-weight: bold;
+}
+.home + #footer {
+  background-color: white;
+}
+
 @media screen and (min-width: 320px) {
   .value-prop .icon {
     font-size: 60px;


### PR DESCRIPTION
This adds additional sections to the home page based on #28 

![screencapture-localhost-1337](https://cloud.githubusercontent.com/assets/170641/6242845/606af7f0-b704-11e4-96fc-d1dea51e4608.png)

I did not implement the opportunity cards. Building those cards is a fairly intense operation for the server with several DB queries. Seems best to avoid that overhead on the homepage. If it's important, we can look into optimizing task listing, but that's a larger task. Otherwise, this closes #28